### PR TITLE
add feat: merchant item show page links to an edit page with a form t…

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,30 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:show, :edit, :update]
+
   def index
     @merchant = Merchant.find(params[:merchant_id])
   end
 
   def show
-    @item = Item.find(params[:id])
+
   end
 
+  def edit
+
+  end
+
+  def update
+    @item.update(item_params)
+    flash.notice = "Item Successfully Updated"
+    redirect_to merchant_item_path(@item.merchant, @item)
+  end
+
+  private
+    def item_params
+      params.permit(:name, :description, :unit_price)
+    end
+
+    def set_item
+      @item = Item.find(params[:id])
+    end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,11 @@
+<h1>Item Edit Page</h1>
+
+<%= form_with url: merchant_item_path, method: :patch do |f| %>
+  <%= f.label :name, "Name" %>
+  <%= f.text_field :name, value: @item.name %>
+  <%= f.label :description, "Description" %>
+  <%= f.text_field :description, value: @item.description %>
+  <%= f.label :unit_price, "Current Price" %>
+  <%= f.number_field :unit_price, value: @item.unit_price %>
+  <%= f.submit "Submit" %>
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,5 +1,8 @@
 <h1>Merchant Item Show Page</h1>
 
+<p><%= flash.notice %></p>
+
 <h2><%= @item.name %></h2>
 <p>Description: <%= @item.description %></p>
 <p>Current Price: <%= @item.unit_price %></p>
+<p><%= link_to "Update", edit_merchant_item_path(@item.merchant, @item) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
 
   resources :merchants, except: [:show] do 
     resources :invoices
-    resources :items, only: [:index, :show]
+    resources :items
   end
 
   get '/merchants/:merchant_id/dashboard', to: 'merchants#show'

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Item Update' do
+  let!(:carly) { Merchant.create!(name: "Carly Simon's Candy Silo")}
+
+  let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500) }
+
+  describe 'when I arrive, I see a form to update the item' do
+    it 'has fields filled out with current item attributes' do
+      visit edit_merchant_item_path(carly, peanut)
+
+      expect(page).to have_field('Name', with: peanut.name)
+      expect(page).to have_field('Description', with: peanut.description)
+      expect(page).to have_field('Current Price', with: peanut.unit_price)
+    end
+
+    describe 'when I update the information' do
+      describe 'it updates the item, takes me back to item show' do
+        it 'and displays flash msg feedback' do
+
+          visit merchant_item_path(carly, peanut)
+
+          expect(page).to have_content("Peanut Bronzinos")
+
+          visit edit_merchant_item_path(carly, peanut)
+
+          fill_in('Name', with: "Peanut Charles Bronson")
+          click_on 'Submit'
+
+          expect(current_path).to eq(merchant_item_path(carly, peanut))
+          expect(page).to have_content("Peanut Charles Bronson")
+          expect(page).to have_content("Item Successfully Updated")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'Merchant Items Show Page' do
 
   let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200) }
   let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500) }
-  let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900) }
-  let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200) }
 
   describe 'when I click on an item from the merchant items index' do
     it 'takes me to that items show page' do
@@ -23,6 +21,17 @@ RSpec.describe 'Merchant Items Show Page' do
       expect(page).to have_content(licorice.name)
       expect(page).to have_content(licorice.description)
       expect(page).to have_content(licorice.unit_price)
+      expect(page).to_not have_content(peanut.name)
+    end
+  end
+
+  describe 'the item show page' do
+    it 'has a link to update item info' do
+      visit merchant_item_path(carly, licorice)
+      
+      click_on "Update"
+
+      expect(current_path).to eq(edit_merchant_item_path(carly, licorice))
     end
   end
 end


### PR DESCRIPTION
Merchant Item show page now links to an edit page
Edit page has forms prefilled with existing values
Upon successful form submit, user is returned to previous page
Flash message informs user of successful update

Implemented flash message just in the html.erb file for this story, but we should talk about sticking it in the main layout, since I'm guessing this isn't the only story that will involve using them!