### PR TITLE
Merchant item disable/enable

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,14 +14,19 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item.update(item_params)
-    flash.notice = "Item Successfully Updated"
-    redirect_to merchant_item_path(@item.merchant, @item)
+    if params[:enabled].present?
+      @item.update(item_params)
+      redirect_to merchant_items_path(@item.merchant)
+    else
+      @item.update(item_params)
+      flash.notice = "Item Successfully Updated"
+      redirect_to merchant_item_path(@item.merchant, @item)
+    end
   end
 
   private
     def item_params
-      params.permit(:name, :description, :unit_price)
+      params.permit(:name, :description, :unit_price, :enabled)
     end
 
     def set_item

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,3 +2,16 @@ class Merchant < ApplicationRecord
   has_many :items
   validates :name, presence: true
 end
+
+#though methods are supposed to be public by default, for some reason these are private unless specified public. not sure why that is.
+public
+def enabled_items
+  items.where(enabled: true)
+end
+
+def disabled_items
+  items.where(enabled: false)
+end
+
+
+

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,11 +1,21 @@
 <h1>Merchant Items Index</h1>
 
 <h2><%= @merchant.name %></h2>
-<h3>Items</h3>
-<ul>
-  <% @merchant.items.each do |item| %>
-    <li>
+<h3>Enabled Items</h3>
+<ul id="enabled_items">
+  <% @merchant.enabled_items.each do |item| %>
+    <li id="item-<%= item.id %>">
       <%= link_to item.name, merchant_item_path(@merchant, item) %>
+      <%= button_to "Disable", merchant_item_path(@merchant, item), method: :patch, params: { enabled: false } %>
+    </li>
+  <% end %>
+</ul>
+<h3>Disabled Items</h3>
+<ul id="disabled_items">
+  <% @merchant.disabled_items.each do |item| %>
+    <li id="item-<%= item.id %>">
+      <%= link_to item.name, merchant_item_path(@merchant, item) %>
+      <%= button_to "Enable", merchant_item_path(@merchant, item), method: :patch, params: { enabled: true } %>
     </li>
   <% end %>
 </ul>

--- a/db/migrate/20220913010148_create_items.rb
+++ b/db/migrate/20220913010148_create_items.rb
@@ -4,6 +4,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.string :name
       t.string :description
       t.integer :unit_price
+      t.boolean :enabled, default: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2022_09_13_113710) do
     t.string "name"
     t.string "description"
     t.integer "unit_price"
+    t.boolean "enabled", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "merchant_id"

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -4,18 +4,18 @@ RSpec.describe 'Merchant Items Index' do
   let!(:carly) { Merchant.create!(name: "Carly Simon's Candy Silo")}
   let!(:bmv) { Merchant.create!(name: "Bavarian Motor Velocycles")}
 
-  let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200) }
-  let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500) }
-  let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900) }
-  let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200) }
+  let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200, enabled: true) }
+  let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500, enabled: true) }
+  let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900, enabled: false) }
+  let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200, enabled: false) }
 
-  let!(:skooter) { bmv.items.create!(name: "Hollenskooter", description: "Some stuff", unit_price: 12000) }
-  let!(:rider) { bmv.items.create!(name: "Hosenpfloofer", description: "Some stuff", unit_price: 220000) }
+  let!(:skooter) { bmv.items.create!(name: "Hollenskooter", description: "Some stuff", unit_price: 12000, enabled: true) }
+  let!(:rider) { bmv.items.create!(name: "Hosenpfloofer", description: "Some stuff", unit_price: 220000, enabled: true) }
 
   describe 'merchant items index page' do
     it 'lists the names of all items' do
       visit merchant_items_path(carly)
-
+      save_and_open_page
       expect(page).to have_content(licorice.name)
       expect(page).to have_content(peanut.name)
       expect(page).to have_content(choco_waffle.name)
@@ -29,15 +29,75 @@ RSpec.describe 'Merchant Items Index' do
       expect(page).to_not have_content(rider.name)
     end
 
-    # commented out because merchant items show tests this exactly. up to interpretation which spec it belongs in!
-    # it 'items link to merchant item show page' do
-    #   visit merchant_items_path(carly)
+    it 'has sections for enabled and disabled items' do
+      visit merchant_items_path(carly)
 
-    #   click_on licorice.name
+      within("#enabled_items") do
+        expect(page).to have_content(licorice.name)
+        expect(page).to_not have_content(hummus.name)
+      end
 
-    #   expect(current_path).to eq(merchant_item_path(carly, licorice))
-    # end
+      within("#disabled_items") do
+        expect(page).to have_content(hummus.name)
+        expect(page).to_not have_content(licorice.name)
+      end
+    end
+    
+    describe 'for each enabled item' do
+      it 'has a button to disable item' do
+        visit merchant_items_path(carly)
 
+        within("#enabled_items") do
+          expect(page).to have_content(licorice.name)
+        end
+  
+        within("#disabled_items") do
+          expect(page).to_not have_content(licorice.name)
+        end
+
+        within("#item-#{licorice.id}") do
+          click_on "Disable"
+        end
+
+        expect(current_path).to eq(merchant_items_path(carly))
+
+        within("#enabled_items") do
+          expect(page).to_not have_content(licorice.name)
+        end
+  
+        within("#disabled_items") do
+          expect(page).to have_content(licorice.name)
+        end
+      end
+    end
+
+    describe 'for each disabled item' do
+      it 'has a button to enable item' do
+        visit merchant_items_path(carly)
+
+        within("#disabled_items") do
+          expect(page).to have_content(hummus.name)
+        end
+  
+        within("#enabled_items") do
+          expect(page).to_not have_content(hummus.name)
+        end
+
+        within("#item-#{hummus.id}") do
+          click_on "Enable"
+        end
+
+        expect(current_path).to eq(merchant_items_path(carly))
+
+        within("#disabled_items") do
+          expect(page).to_not have_content(hummus.name)
+        end
+  
+        within("#enabled_items") do
+          expect(page).to have_content(hummus.name)
+        end
+      end
+    end
   end
 end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 RSpec.describe Item, type: :model do
+
   describe 'relationships' do
     it { should belong_to(:merchant) }
     it { should have_many :invoice_items }

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -1,5 +1,12 @@
 require 'rails_helper'
 RSpec.describe Merchant, type: :model do
+  let!(:carly) { Merchant.create!(name: "Carly Simon's Candy Silo")}
+
+  let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200, enabled: true) }
+  let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500, enabled: true) }
+  let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900, enabled: false) }
+  let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200, enabled: false) }
+  
   describe 'relationships' do
     it { should have_many :items }
   end
@@ -16,6 +23,18 @@ RSpec.describe Merchant, type: :model do
     describe '#search' do
       it 'returns partial matches' do
        #method goes here
+      end
+    end
+
+    describe '#enabled_items' do
+      it 'returns an array of enabled items' do
+        expect(carly.enabled_items).to eq([licorice, peanut])
+      end
+    end
+
+    describe '#disabled_items' do
+      it 'returns an array of enabled items' do
+        expect(carly.disabled_items).to eq([choco_waffle, hummus])
       end
     end
   end


### PR DESCRIPTION
Update CreateItems migration to add a boolean attribute enabled: true/false, defaults true
Added Enabled/Disabled Item sections to Merchant Items Index
Added buttons to enable or disable items depending on their current state