### PR TITLE
Merchant item create

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,12 +1,24 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_merchant, only: [:index, :create]
 
   def index
-    @merchant = Merchant.find(params[:merchant_id])
+
   end
 
   def show
 
+  end
+
+  def new
+
+  end
+
+  def create
+    @item = @merchant.items.new(item_params)
+    @item.save
+    flash.notice = "New Item #{@item.name} Created"
+    redirect_to merchant_items_path(@merchant)
   end
 
   def edit
@@ -31,5 +43,9 @@ class ItemsController < ApplicationController
 
     def set_item
       @item = Item.find(params[:id])
+    end
+
+    def set_merchant
+      @merchant = Merchant.find(params[:merchant_id])
     end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -19,3 +19,5 @@
     </li>
   <% end %>
 </ul>
+
+<%= link_to "Create New Item", new_merchant_item_path(@merchant) %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,0 +1,11 @@
+<h1>New Item Page</h1>
+
+<%= form_with url: merchant_items_path, method: :post do |f| %>
+  <%= f.label :name, "Name" %>
+  <%= f.text_field :name %>
+  <%= f.label :description, "Description" %>
+  <%= f.text_field :description %>
+  <%= f.label :unit_price, "Current Price" %>
+  <%= f.number_field :unit_price %>
+  <%= f.submit "Submit" %>
+<% end %>

--- a/db/migrate/20220913010148_create_items.rb
+++ b/db/migrate/20220913010148_create_items.rb
@@ -4,7 +4,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.string :name
       t.string :description
       t.integer :unit_price
-      t.boolean :enabled, default: true
+      t.boolean :enabled, default: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2022_09_13_113710) do
     t.string "name"
     t.string "description"
     t.integer "unit_price"
-    t.boolean "enabled", default: true
+    t.boolean "enabled", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "merchant_id"

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Merchant Items Index' do
   describe 'merchant items index page' do
     it 'lists the names of all items' do
       visit merchant_items_path(carly)
-      save_and_open_page
+
       expect(page).to have_content(licorice.name)
       expect(page).to have_content(peanut.name)
       expect(page).to have_content(choco_waffle.name)

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -98,6 +98,18 @@ RSpec.describe 'Merchant Items Index' do
         end
       end
     end
+
+    describe 'creating a new item' do
+      it 'has a link to create a new item' do
+        visit merchant_items_path(carly)
+        
+        expect(page).to have_link("Create New Item")
+
+        click_link "Create New Item"
+
+        expect(current_path).to eq(new_merchant_item_path(carly))
+      end
+    end
   end
 end
 

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'New Merchant Item Spec' do
+  let!(:carly) { Merchant.create!(name: "Carly Simon's Candy Silo")}
+
+  it 'has a form to create a new item' do
+    visit new_merchant_item_path(carly)
+
+    expect(page).to have_field(:name)
+    expect(page).to have_field(:description)
+    expect(page).to have_field(:unit_price)
+  end
+
+  describe 'when I fill out the form and click submit' do
+    it 'creates the item and redirects to merchant item index' do
+      visit new_merchant_item_path(carly)
+
+      fill_in(:name, with: "Zucchini Splendour")
+      fill_in(:description, with: "Some stuff")
+      fill_in(:unit_price, with: 250)
+      click_on "Submit"
+
+      expect(current_path).to eq(merchant_items_path(carly))
+
+      expect(page).to have_content("Zucchini Splendour")
+      expect(carly.items.last.enabled).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Add feat: can now create items from merchant index using a form.
Changed: item attribute enabled now defaults false, as specified in user story