### PR TITLE
Merchant items index 5 most popular items

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,11 +2,11 @@ class Merchant < ApplicationRecord
   has_many :items
   validates :name, presence: true
 
+  #looking at this now, would this also work as a class method in the customer model?
   def transactions_top_5
       Customer.joins(invoices: :transactions).where( transactions: {result: 1}).group(:id).order("transactions.count desc").limit(5)
   end
 
-  #though methods are supposed to be public by default, for some reason these are private unless specified public. not sure why that is.
   def enabled_items
     items.where(enabled: true)
   end
@@ -15,7 +15,9 @@ class Merchant < ApplicationRecord
     items.where(enabled: false)
   end
 
+  #could this also be a class method?
   def top_5_items
-    require 'pry'; binding.pry
+    items = Item.joins(invoices: :transactions).group(:id, :name).where( transactions: {result: 1}, merchant_id: self.id).sum("invoice_items.unit_price*quantity")
+    items.sort_by { |item, revenue| revenue }.first(5).reverse.to_h
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,7 +7,6 @@ class Merchant < ApplicationRecord
   end
 
   #though methods are supposed to be public by default, for some reason these are private unless specified public. not sure why that is.
-  public
   def enabled_items
     items.where(enabled: true)
   end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -14,4 +14,8 @@ class Merchant < ApplicationRecord
   def disabled_items
     items.where(enabled: false)
   end
+
+  def top_5_items
+    require 'pry'; binding.pry
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -21,10 +21,10 @@
 </ul>
 <h3>Top 5 Items By Revenue</h3>
 <ol id="top-five">
-  <% @merchant.top_5_items.each do |item| %>
-    <li id="top-item-<%= item.id %>">
-      <%= item.name %>
-      <%= item.revenue %>
+  <% @merchant.top_5_items.each do |item, revenue| %>
+    <li id="top-item-<%= item[0] %>">
+      <%= link_to item[1], merchant_item_path(@merchant, item[0]) %>
+      <p>Total Revenue: <%= revenue %></p>
     </li>
   <% end %>
 </ol>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -19,3 +19,12 @@
     </li>
   <% end %>
 </ul>
+<h3>Top 5 Items By Revenue</h3>
+<ol id="top-five">
+  <% @merchant.top_5_items.each do |item| %>
+    <li id="top-item-<%= item.id %>">
+      <%= item.name %>
+      <%= item.revenue %>
+    </li>
+  <% end %>
+</ol>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -98,6 +98,47 @@ RSpec.describe 'Merchant Items Index' do
         end
       end
     end
+
+    describe 'it lists the 5 most popular items' do
+      describe 'and the total revenue each item generates' do
+      
+      
+      let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200, enabled: true) }
+      let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500, enabled: true) }
+      let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900, enabled: false) }
+      let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200, enabled: false) }
+      
+      let!(:alaina) { Customer.create!(first_name: “Alaina”, last_name: “Kneiling”)}
+      let!(:whitney) { Customer.create!(first_name: “Whitney”, last_name: “Gains”)}
+
+      let!(:whitney_invoice1) { whitney.invoices.create!(status: "completed")}
+      let!(:whitney_invoice2) { whitney.invoices.create!(status: "completed")}
+      let!(:whitney_invoice3) { whitney.invoices.create!(status: "completed")}
+      let!(:whitney_invoice4) { whitney.invoices.create!(status: "completed")}
+      let!(:whitney_invoice5) { whitney.invoices.create!(status: "completed")}
+      let!(:whitney_invoice6) { whitney.invoices.create!(status: "completed")}
+      let!(:alaina_invoice1) { alaina.invoices.create!(status: "completed")}
+      let!(:alaina_invoice2) { alaina.invoices.create!(status: "in_progress")}
+      let!(:alaina_invoice3) { alaina.invoices.create!(status: "completed")}
+      let!(:alaina_invoice4) { alaina.invoices.create!(status: "completed")}
+      let!(:alaina_invoice5) { alaina.invoices.create!(status: "completed")}
+
+
+        it 'lists the top 5 items by revenue generated' do
+          visit merchant_items_path(carly)
+
+          
+
+          within("#top_five") do
+            expect(item).to appear_before(item)
+            expect(item).to appear_before(item)
+            expect(item).to appear_before(item)
+            expect(item).to appear_before(item)
+            expect(item).to appear_before(item)
+          end
+        end
+      end
+    end
   end
 end
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -7,55 +7,55 @@ RSpec.describe 'Merchant Items Index' do
   let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200, enabled: true) }
   let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500, enabled: true) }
   let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900, enabled: false) }
-  let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200, enabled: false) }
+  let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1300, enabled: false) }
+  let!(:grobles) { carly.items.create!(name: "Kasegrobles", description: "Some stuff", unit_price: 1400, enabled: true) }
+  let!(:knutels) { carly.items.create!(name: "Schmooknutels", description: "Some stuff", unit_price: 800, enabled: true) }
+  let!(:brontos) { carly.items.create!(name: "Walder Brontos", description: "Some stuff", unit_price: 700, enabled: true) }
+  let!(:grongos) { carly.items.create!(name: "Funky Grongos", description: "Some stuff", unit_price: 600, enabled: true) }
 
   let!(:skooter) { bmv.items.create!(name: "Hollenskooter", description: "Some stuff", unit_price: 12000, enabled: true) }
   let!(:rider) { bmv.items.create!(name: "Hosenpfloofer", description: "Some stuff", unit_price: 220000, enabled: true) }
 
-  let!(:alaina) { Customer.create!(first_name: “Alaina”, last_name: “Kneiling”)}
-  let!(:whitney) { Customer.create!(first_name: “Whitney”, last_name: “Gains”)}
+  let!(:alaina) { Customer.create!(first_name: "Alaina", last_name: "Kneiling")}
+  let!(:whitney) { Customer.create!(first_name: "Whitney", last_name: "Gains")}
+  
+  let!(:invoice1) { alaina.invoices.create!(status: "completed")}
+  let!(:invoice2) { alaina.invoices.create!(status: "in_progress")}
+  let!(:invoice3) { alaina.invoices.create!(status: "completed")}
+  let!(:invoice4) { alaina.invoices.create!(status: "completed")}
+  let!(:invoice5) { alaina.invoices.create!(status: "completed")}
+  let!(:invoice6) { alaina.invoices.create!(status: "completed")}
+  let!(:invoice7) { whitney.invoices.create!(status: "completed")}
+  let!(:invoice8) { whitney.invoices.create!(status: "completed")}
+  let!(:invoice9) { whitney.invoices.create!(status: "completed")}
+  let!(:invoice10) { whitney.invoices.create!(status: "completed")}
 
-  let!(:whitney_invoice1) { whitney.invoices.create!(status: "completed")}
-  let!(:whitney_invoice2) { whitney.invoices.create!(status: "completed")}
-  let!(:whitney_invoice3) { whitney.invoices.create!(status: "completed")}
-  let!(:whitney_invoice4) { whitney.invoices.create!(status: "completed")}
-  let!(:whitney_invoice5) { whitney.invoices.create!(status: "completed")}
-  let!(:whitney_invoice6) { whitney.invoices.create!(status: "completed")}
-  let!(:alaina_invoice1) { alaina.invoices.create!(status: "completed")}
-  let!(:alaina_invoice2) { alaina.invoices.create!(status: "in_progress")}
-  let!(:alaina_invoice3) { alaina.invoices.create!(status: "completed")}
-  let!(:alaina_invoice4) { alaina.invoices.create!(status: "completed")}
-  let!(:alaina_invoice5) { alaina.invoices.create!(status: "completed")}
+  let!(:transaction1) { invoice1.transactions.create!(credit_card_number: "4654405418249632", result: "success")}
+  let!(:transaction2) { invoice2.transactions.create!(credit_card_number: "4654405418249632", result: "success")}
+  let!(:transaction3) { invoice3.transactions.create!(credit_card_number: "4654405418249632", result: "success")}
+  let!(:transaction4) { invoice4.transactions.create!(credit_card_number: "4654405418249632", result: "success")}
+  let!(:transaction5) { invoice5.transactions.create!(credit_card_number: "4654405418249632", result: "failed")}
+  let!(:transaction6) { invoice6.transactions.create!(credit_card_number: "4654405418249632", result: "success")}
+  let!(:transaction7) { invoice7.transactions.create!(credit_card_number: "4654405418249632", result: "success")}
+  let!(:transaction8) { invoice8.transactions.create!(credit_card_number: "4654405418249632", result: "success")}
+  let!(:transaction9) { invoice9.transactions.create!(credit_card_number: "4654405418249632", result: "success")}
+  let!(:transaction10) { invoice10.transactions.create!(credit_card_number: "4654405418249632", result: "failed")}
 
-  let!(:alaina_invoice1_transaction) { alaina_invoice1.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:alaina_invoice2_transaction) { alaina_invoice2.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:alaina_invoice3_transaction) { alaina_invoice3.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:alaina_invoice4_transaction) { alaina_invoice4.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:alaina_invoice5_transaction) { alaina_invoice5.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:whitney_invoice1_transaction) { whitney_invoice1.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:whitney_invoice2_transaction) { whitney_invoice2.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:whitney_invoice3_transaction) { whitney_invoice3.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:whitney_invoice4_transaction) { whitney_invoice4.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:whitney_invoice5_transaction) { whitney_invoice5.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-  let!(:whitney_invoice6_transaction) { whitney_invoice6.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
-
-  let!(:alainainvoice1_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: gold_earrings.id, quantity: 4, unit_price: 1300, status:"packaged" )}
-  let!(:alainainvoice2_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice2.id, item_id: gold_earrings.id, quantity: 40, unit_price: 1500, status:"shipped" )}
-  let!(:alainainvoice3_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice3.id, item_id: gold_earrings.id, quantity: 12, unit_price: 1600, status:"shipped" )}
-  let!(:alainainvoice4_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice4.id, item_id: gold_earrings.id, quantity: 4, unit_price: 2400, status:"shipped" )}
-  let!(:alainainvoice5_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice5.id, item_id: gold_earrings.id, quantity: 243, unit_price: 27000, status:"shipped" )}
-
-  let!(:whitneyinvoice1_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice1.id, item_id: silver_necklace.id, quantity: 3, unit_price: 270, status:"shipped" )}
-  let!(:whitneyinvoice2_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice2.id, item_id: silver_necklace.id, quantity: 31, unit_price: 270, status:"shipped" )}
-  let!(:whitneyinvoice3_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice3.id, item_id: silver_necklace.id, quantity: 1, unit_price: 270, status:"shipped" )}
-  let!(:whitneyinvoice4_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice4.id, item_id: silver_necklace.id, quantity: 10, unit_price: 270, status:"shipped" )}
-  let!(:whitneyinvoice5_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice5.id, item_id: silver_necklace.id, quantity: 1, unit_price: 270, status:"shipped" )}
-  let!(:whitneyinvoice6_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice6.id, item_id: silver_necklace.id, quantity: 3, unit_price: 270, status:"shipped" )}
+  let!(:invoice_item1) { InvoiceItem.create!(invoice_id: invoice1.id, item_id: licorice.id, quantity: 4, unit_price: 2000, status:"packaged" )}
+  let!(:invoice_item2) { InvoiceItem.create!(invoice_id: invoice2.id, item_id: peanut.id, quantity: 6, unit_price: 2300, status:"packaged")}
+  let!(:invoice_item3) { InvoiceItem.create!(invoice_id: invoice3.id, item_id: grobles.id, quantity: 7, unit_price: 1900, status:"packaged")}
+  let!(:invoice_item4) { InvoiceItem.create!(invoice_id: invoice4.id, item_id: knutels.id, quantity: 1, unit_price: 1900, status:"packaged")}
+  let!(:invoice_item5) { InvoiceItem.create!(invoice_id: invoice5.id, item_id: brontos.id, quantity: 2, unit_price: 1000, status:"packaged")}
+  let!(:invoice_item6) { InvoiceItem.create!(invoice_id: invoice6.id, item_id: grongos.id, quantity: 3, unit_price: 1800, status:"packaged")}
+  let!(:invoice_item7) { InvoiceItem.create!(invoice_id: invoice7.id, item_id: grobles.id, quantity: 8, unit_price: 1900, status:"packaged")}
+  let!(:invoice_item8) { InvoiceItem.create!(invoice_id: invoice8.id, item_id: grongos.id, quantity: 10, unit_price: 1800, status:"packaged")}
+  let!(:invoice_item9) { InvoiceItem.create!(invoice_id: invoice9.id, item_id: licorice.id, quantity: 9, unit_price: 2000, status:"packaged")}
+  let!(:invoice_item10) { InvoiceItem.create!(invoice_id: invoice10.id, item_id: peanut.id, quantity: 4, unit_price: 2300, status:"packaged")}
 
   describe 'merchant items index page' do
     it 'lists the names of all items' do
       visit merchant_items_path(carly)
-      save_and_open_page
+
       expect(page).to have_content(licorice.name)
       expect(page).to have_content(peanut.name)
       expect(page).to have_content(choco_waffle.name)
@@ -141,34 +141,19 @@ RSpec.describe 'Merchant Items Index' do
 
     describe 'it lists the 5 most popular items' do
       describe 'and the total revenue each item generates' do
-      
-      
-      # let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200, enabled: true) }
-      # let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500, enabled: true) }
-      # let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900, enabled: false) }
-      # let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200, enabled: false) 
+        it 'lists the top 5 items by revenue generated' do
+          visit merchant_items_path(carly)
 
-
-        # it 'lists the top 5 items by revenue generated' do
-        #   visit merchant_items_path(carly)
-
-          
-
-        #   within("#top_five") do
-        #     expect(item).to appear_before(item)
-        #     expect(item).to appear_before(item)
-        #     expect(item).to appear_before(item)
-        #     expect(item).to appear_before(item)
-        #     expect(item).to appear_before(item)
-        #   end
-        # end
+          within("#top-five") do
+            expect(item).to appear_before(item)
+            expect(item).to appear_before(item)
+            expect(item).to appear_before(item)
+            expect(item).to appear_before(item)
+            expect(item).to appear_before(item)
+          end
+        end
       end
     end
   end
 end
-
-# As a merchant,
-# When I visit my merchant items index page ("merchants/merchant_id/items")
-# I see a list of the names of all of my items
-# And I do not see items for any other merchant
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -145,11 +145,14 @@ RSpec.describe 'Merchant Items Index' do
           visit merchant_items_path(carly)
 
           within("#top-five") do
-            expect(item).to appear_before(item)
-            expect(item).to appear_before(item)
-            expect(item).to appear_before(item)
-            expect(item).to appear_before(item)
-            expect(item).to appear_before(item)
+            expect(grobles.name).to appear_before(licorice.name)
+            expect(licorice.name).to appear_before(grongos.name)
+            expect(grongos.name).to appear_before(peanut.name)
+            expect(peanut.name).to appear_before(knutels.name)
+          end
+
+          within("#top-item-#{grobles.id}") do
+            expect(page).to have_content("Total Revenue: 28500")
           end
         end
       end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -12,6 +12,46 @@ RSpec.describe 'Merchant Items Index' do
   let!(:skooter) { bmv.items.create!(name: "Hollenskooter", description: "Some stuff", unit_price: 12000, enabled: true) }
   let!(:rider) { bmv.items.create!(name: "Hosenpfloofer", description: "Some stuff", unit_price: 220000, enabled: true) }
 
+  let!(:alaina) { Customer.create!(first_name: “Alaina”, last_name: “Kneiling”)}
+  let!(:whitney) { Customer.create!(first_name: “Whitney”, last_name: “Gains”)}
+
+  let!(:whitney_invoice1) { whitney.invoices.create!(status: "completed")}
+  let!(:whitney_invoice2) { whitney.invoices.create!(status: "completed")}
+  let!(:whitney_invoice3) { whitney.invoices.create!(status: "completed")}
+  let!(:whitney_invoice4) { whitney.invoices.create!(status: "completed")}
+  let!(:whitney_invoice5) { whitney.invoices.create!(status: "completed")}
+  let!(:whitney_invoice6) { whitney.invoices.create!(status: "completed")}
+  let!(:alaina_invoice1) { alaina.invoices.create!(status: "completed")}
+  let!(:alaina_invoice2) { alaina.invoices.create!(status: "in_progress")}
+  let!(:alaina_invoice3) { alaina.invoices.create!(status: "completed")}
+  let!(:alaina_invoice4) { alaina.invoices.create!(status: "completed")}
+  let!(:alaina_invoice5) { alaina.invoices.create!(status: "completed")}
+
+  let!(:alaina_invoice1_transaction) { alaina_invoice1.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:alaina_invoice2_transaction) { alaina_invoice2.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:alaina_invoice3_transaction) { alaina_invoice3.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:alaina_invoice4_transaction) { alaina_invoice4.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:alaina_invoice5_transaction) { alaina_invoice5.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:whitney_invoice1_transaction) { whitney_invoice1.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:whitney_invoice2_transaction) { whitney_invoice2.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:whitney_invoice3_transaction) { whitney_invoice3.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:whitney_invoice4_transaction) { whitney_invoice4.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:whitney_invoice5_transaction) { whitney_invoice5.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:whitney_invoice6_transaction) { whitney_invoice6.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+
+  let!(:alainainvoice1_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: gold_earrings.id, quantity: 4, unit_price: 1300, status:"packaged" )}
+  let!(:alainainvoice2_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice2.id, item_id: gold_earrings.id, quantity: 40, unit_price: 1500, status:"shipped" )}
+  let!(:alainainvoice3_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice3.id, item_id: gold_earrings.id, quantity: 12, unit_price: 1600, status:"shipped" )}
+  let!(:alainainvoice4_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice4.id, item_id: gold_earrings.id, quantity: 4, unit_price: 2400, status:"shipped" )}
+  let!(:alainainvoice5_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice5.id, item_id: gold_earrings.id, quantity: 243, unit_price: 27000, status:"shipped" )}
+
+  let!(:whitneyinvoice1_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice1.id, item_id: silver_necklace.id, quantity: 3, unit_price: 270, status:"shipped" )}
+  let!(:whitneyinvoice2_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice2.id, item_id: silver_necklace.id, quantity: 31, unit_price: 270, status:"shipped" )}
+  let!(:whitneyinvoice3_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice3.id, item_id: silver_necklace.id, quantity: 1, unit_price: 270, status:"shipped" )}
+  let!(:whitneyinvoice4_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice4.id, item_id: silver_necklace.id, quantity: 10, unit_price: 270, status:"shipped" )}
+  let!(:whitneyinvoice5_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice5.id, item_id: silver_necklace.id, quantity: 1, unit_price: 270, status:"shipped" )}
+  let!(:whitneyinvoice6_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice6.id, item_id: silver_necklace.id, quantity: 3, unit_price: 270, status:"shipped" )}
+
   describe 'merchant items index page' do
     it 'lists the names of all items' do
       visit merchant_items_path(carly)
@@ -103,40 +143,25 @@ RSpec.describe 'Merchant Items Index' do
       describe 'and the total revenue each item generates' do
       
       
-      let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200, enabled: true) }
-      let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500, enabled: true) }
-      let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900, enabled: false) }
-      let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200, enabled: false) }
-      
-      let!(:alaina) { Customer.create!(first_name: “Alaina”, last_name: “Kneiling”)}
-      let!(:whitney) { Customer.create!(first_name: “Whitney”, last_name: “Gains”)}
-
-      let!(:whitney_invoice1) { whitney.invoices.create!(status: "completed")}
-      let!(:whitney_invoice2) { whitney.invoices.create!(status: "completed")}
-      let!(:whitney_invoice3) { whitney.invoices.create!(status: "completed")}
-      let!(:whitney_invoice4) { whitney.invoices.create!(status: "completed")}
-      let!(:whitney_invoice5) { whitney.invoices.create!(status: "completed")}
-      let!(:whitney_invoice6) { whitney.invoices.create!(status: "completed")}
-      let!(:alaina_invoice1) { alaina.invoices.create!(status: "completed")}
-      let!(:alaina_invoice2) { alaina.invoices.create!(status: "in_progress")}
-      let!(:alaina_invoice3) { alaina.invoices.create!(status: "completed")}
-      let!(:alaina_invoice4) { alaina.invoices.create!(status: "completed")}
-      let!(:alaina_invoice5) { alaina.invoices.create!(status: "completed")}
+      # let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200, enabled: true) }
+      # let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500, enabled: true) }
+      # let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900, enabled: false) }
+      # let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200, enabled: false) 
 
 
-        it 'lists the top 5 items by revenue generated' do
-          visit merchant_items_path(carly)
+        # it 'lists the top 5 items by revenue generated' do
+        #   visit merchant_items_path(carly)
 
           
 
-          within("#top_five") do
-            expect(item).to appear_before(item)
-            expect(item).to appear_before(item)
-            expect(item).to appear_before(item)
-            expect(item).to appear_before(item)
-            expect(item).to appear_before(item)
-          end
-        end
+        #   within("#top_five") do
+        #     expect(item).to appear_before(item)
+        #     expect(item).to appear_before(item)
+        #     expect(item).to appear_before(item)
+        #     expect(item).to appear_before(item)
+        #     expect(item).to appear_before(item)
+        #   end
+        # end
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -95,11 +95,11 @@ RSpec.describe Merchant, type: :model do
 
 
   describe 'class methods' do
-    describe '#search' do
-      xit 'returns partial matches' do
-       #method goes here
-      end
-    end
+    # describe '#search' do
+    #   xit 'returns partial matches' do
+    #    #method goes here
+    #   end
+    # end
 
     describe '#enabled_items' do
       it 'returns an array of enabled items' do
@@ -116,11 +116,16 @@ RSpec.describe Merchant, type: :model do
 
   describe 'instance methods' do
     describe '#transactions_top_5' do
-     it 'finds the top 5 customers with the most successful transactions with a particular merchant' do
+      it 'finds the top 5 customers with the most successful transactions with a particular merchant' do
 
-      expect(jewlery_city.transactions_top_5.pluck(:first_name)).to eq(["Whitney", "Alaina", "Eddie", "Polina", "Ryan"])
-     end
+        expect(jewlery_city.transactions_top_5.pluck(:first_name)).to eq(["Whitney", "Alaina", "Eddie", "Polina", "Ryan"])
+      end
+    end
+
+    describe '#top_5_items' do
+      it 'returns an array of the top 5 items by revenue' do
+        expect(jewlery_city.top_5_items).to eq([])
+      end
     end
   end
-
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -1,12 +1,5 @@
 require 'rails_helper'
 RSpec.describe Merchant, type: :model do
-  let!(:carly) { Merchant.create!(name: "Carly Simon's Candy Silo")}
-
-  let!(:licorice) { carly.items.create!(name: "Licorice Funnels", description: "Some stuff", unit_price: 1200, enabled: true) }
-  let!(:peanut) { carly.items.create!(name: "Peanut Bronzinos", description: "Some stuff", unit_price: 1500, enabled: true) }
-  let!(:choco_waffle) { carly.items.create!(name: "Chocolate Waffles Florentine", description: "Some stuff", unit_price: 900, enabled: false) }
-  let!(:hummus) { carly.items.create!(name: "Hummus Snocones", description: "Some stuff", unit_price: 1200, enabled: false) }
-  
   describe 'relationships' do
     it { should have_many :items }
   end
@@ -18,10 +11,10 @@ RSpec.describe Merchant, type: :model do
   let!(:carly_silo) { Merchant.create!(name: "Carly Simon's Candy Silo")}
   let!(:jewlery_city) { Merchant.create!(name: "Jewlery City Merchant")}
 
-  let!(:licorice) { carly_silo.items.create!(name: "Licorice Funnels", description: "Licorice Balls", unit_price: 1200) }
-  let!(:peanut) { carly_silo.items.create!(name: "Peanut Bronzinos", description: "Peanut Caramel Chews", unit_price: 1500) }
-  let!(:choco_waffle) { carly_silo.items.create!(name: "Chocolate Waffles Florentine", description: "Cholately Waffles of Deliciousness", unit_price: 900) }
-  let!(:hummus) { carly_silo.items.create!(name: "Hummus", description: "Creamy Hummus", unit_price: 1200) }
+  let!(:licorice) { carly_silo.items.create!(name: "Licorice Funnels", description: "Licorice Balls", unit_price: 1200, enabled: true) }
+  let!(:peanut) { carly_silo.items.create!(name: "Peanut Bronzinos", description: "Peanut Caramel Chews", unit_price: 1500, enabled: true) }
+  let!(:choco_waffle) { carly_silo.items.create!(name: "Chocolate Waffles Florentine", description: "Cholately Waffles of Deliciousness", unit_price: 900, enabled: false) }
+  let!(:hummus) { carly_silo.items.create!(name: "Hummus", description: "Creamy Hummus", unit_price: 1200, enabled: false) }
 
   let!(:gold_earrings) { jewlery_city.items.create!(name: "Gold Earrings", description: "14k Gold 12' Hoops", unit_price: 12000) }
   let!(:silver_necklace) { jewlery_city.items.create!(name: "Silver Necklace", description: "An everyday wearable silver necklace", unit_price: 220000) }
@@ -110,13 +103,13 @@ RSpec.describe Merchant, type: :model do
 
     describe '#enabled_items' do
       it 'returns an array of enabled items' do
-        expect(carly.enabled_items).to eq([licorice, peanut])
+        expect(carly_silo.enabled_items).to eq([licorice, peanut])
       end
     end
 
     describe '#disabled_items' do
       it 'returns an array of enabled items' do
-        expect(carly.disabled_items).to eq([choco_waffle, hummus])
+        expect(carly_silo.disabled_items).to eq([choco_waffle, hummus])
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Merchant, type: :model do
   let!(:studded_bracelet) { jewlery_city.items.create!(name: "Gold Studded Bracelet", description: "A bracet to make others jealous", unit_price: 2900) }
   let!(:dainty_anklet) { jewlery_city.items.create!(name: "Dainty Ankley", description: "An everyday ankley", unit_price: 2299) }
   let!(:stackable_rings) { jewlery_city.items.create!(name: "Stackable Gold Rings", description: "Small rings to be mixed and matched", unit_price: 1299) }
+  let!(:conch_shell) { jewlery_city.items.create!(name: "Conch Shell Headdress", description: "A beach-ready, waterproof shell hat", unit_price: 5099) }
+  let!(:banana_earrings) { jewlery_city.items.create!(name: "Banana Earrings", description: "A fruit salad for your earlobes", unit_price: 2399) }
+  let!(:nose_ring) { jewlery_city.items.create!(name: "Platinum Nose Ring", description: "They'll never know it's platinum!", unit_price: 4299) }
+  let!(:spiked_wallet_chain) { jewlery_city.items.create!(name: "Spiked Wallet Chain", description: "Keep it close, keep it safe", unit_price: 1599) }
 
   let!(:alaina) { Customer.create!(first_name: "Alaina", last_name: "Kneiling")}
   let!(:whitney) { Customer.create!(first_name: "Whitney", last_name: "Gains")}
@@ -41,6 +45,10 @@ RSpec.describe Merchant, type: :model do
   let!(:alaina_invoice3) { alaina.invoices.create!(status: "completed")}
   let!(:alaina_invoice4) { alaina.invoices.create!(status: "completed")}
   let!(:alaina_invoice5) { alaina.invoices.create!(status: "completed")}
+  let!(:alaina_invoice6) { alaina.invoices.create!(status: "completed")}
+  let!(:alaina_invoice7) { alaina.invoices.create!(status: "completed")}
+  let!(:alaina_invoice8) { alaina.invoices.create!(status: "completed")}
+  let!(:alaina_invoice9) { alaina.invoices.create!(status: "completed")}
   let!(:eddie_invoice1) { eddie.invoices.create!(status: "completed")}
   let!(:eddie_invoice2) { eddie.invoices.create!(status: "completed")}
   let!(:eddie_invoice3) { eddie.invoices.create!(status: "completed")}
@@ -62,6 +70,10 @@ RSpec.describe Merchant, type: :model do
   let!(:alaina_invoice3_transaction) { alaina_invoice3.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
   let!(:alaina_invoice4_transaction) { alaina_invoice4.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
   let!(:alaina_invoice5_transaction) { alaina_invoice5.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:alaina_invoice6_transaction) { alaina_invoice6.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:alaina_invoice7_transaction) { alaina_invoice7.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:alaina_invoice8_transaction) { alaina_invoice8.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
+  let!(:alaina_invoice9_transaction) { alaina_invoice9.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
   let!(:eddie_invoice1_transaction) { eddie_invoice1.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
   let!(:eddie_invoice2_transaction) { eddie_invoice2.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
   let!(:eddie_invoice3_transaction) { eddie_invoice3.transactions.create!(credit_card_number: "4654405418249632", credit_card_expiration_date: nil, result: "success")}
@@ -77,6 +89,10 @@ RSpec.describe Merchant, type: :model do
   let!(:alainainvoice3_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice3.id, item_id: gold_earrings.id, quantity: 12, unit_price: 1600, status:"shipped" )}
   let!(:alainainvoice4_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice4.id, item_id: gold_earrings.id, quantity: 4, unit_price: 2400, status:"shipped" )}
   let!(:alainainvoice5_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice5.id, item_id: gold_earrings.id, quantity: 243, unit_price: 27000, status:"shipped" )}
+  let!(:alainainvoice6_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice6.id, item_id: conch_shell.id, quantity: 1412, unit_price: 12421, status:"shipped" )}
+  let!(:alainainvoice7_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice7.id, item_id: banana_earrings.id, quantity: 122, unit_price: 1242, status:"shipped" )}
+  let!(:alainainvoice8_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice8.id, item_id: nose_ring.id, quantity: 2881, unit_price: 4599, status:"shipped" )}
+  let!(:alainainvoice5_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice9.id, item_id: spiked_wallet_chain.id, quantity: 827, unit_price: 3499, status:"shipped" )}
 
   let!(:whitneyinvoice1_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice1.id, item_id: silver_necklace.id, quantity: 3, unit_price: 270, status:"shipped" )}
   let!(:whitneyinvoice2_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice2.id, item_id: silver_necklace.id, quantity: 31, unit_price: 270, status:"shipped" )}
@@ -118,13 +134,21 @@ RSpec.describe Merchant, type: :model do
     describe '#transactions_top_5' do
       it 'finds the top 5 customers with the most successful transactions with a particular merchant' do
 
-        expect(jewlery_city.transactions_top_5.pluck(:first_name)).to eq(["Whitney", "Alaina", "Eddie", "Polina", "Ryan"])
+        expect(jewlery_city.transactions_top_5.pluck(:first_name)).to eq(["Alaina", "Whitney", "Eddie", "Polina", "Ryan"])
       end
     end
 
     describe '#top_5_items' do
-      it 'returns an array of the top 5 items by revenue' do
-        expect(jewlery_city.top_5_items).to eq([])
+      it 'returns a sorted hash of the top 5 items with [:id, :name] as key and revenue as value' do
+        expect(jewlery_city.top_5_items).to eq(
+            {
+              [banana_earrings.id, "Banana Earrings"]=>151524,
+              [gold_earrings.id, "Gold Earrings"]=>94000,
+              [studded_bracelet.id, "Gold Studded Bracelet"]=>45594,
+              [silver_necklace.id, "Silver Necklace"]=>13230,
+              [dainty_anklet.id, "Dainty Ankley"]=>1890
+            }
+          )
       end
     end
   end


### PR DESCRIPTION
Merchant items index now has a section for top 5 items by revenue generated. 

This one was tough. #top_5_items is an instance method for Merchant, but it may work better as a class method for Item? I'm really not sure.

The return value doesn't contain any ActiveRecord objects, which is frustrating as it makes the View quite a bit less readable than I'd like. I couldn't figure out how to make the revenue calculation into a useable alias, the syntax just seemed to elude me despite lots of googling.

The actual return value is a sorted hash, the keys are arrays of [item_id, item_name], the values are total revenue for that item. This gives us the data we need to work with, but short of grouping solely by id and then using a second ActiveRecord query to build a hash with the actual objects as keys, I'm not sure how else to do it. If anyone has any ideas, I'm very open to hearing them!