### PR TITLE
Merchant invoice show page invoice item information

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -9,5 +9,8 @@ class Invoice < ApplicationRecord
   def self.incomplete_invoices
     where("status = 2").order(:created_at)
   end
- 
+
+  def merchant_items(merchant)
+    self.items.where(items: { merchant_id: merchant.id } ).distinct
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,10 +7,12 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
 
-
-
   def best_sales_date
     date = self.invoices.select(:created_at, "invoice_items.unit_price*quantity as revenue").order("revenue desc", "invoices.created_at desc").first.created_at
     date.strftime("%B %d, %Y")
+  end
+
+  def invoice_item(invoice)
+    InvoiceItem.select("invoice_items.*").where(item_id: self.id, invoice_id: invoice.id).order(created_at: :desc).first
   end
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -1,1 +1,13 @@
 <h1>Invoice Show Page</h1>
+
+<h3>Invoice Items</h3>
+<ul id="invoice_items">
+  <% @invoice.merchant_items(@merchant).each do |item| %>
+    <li id="item_<%= item.id %>">
+      <%= item.name %>
+      <p>Quantity: <%= item.invoice_item(@invoice).quantity %></p>
+      <p>Sale Price: <%= item.invoice_item(@invoice).unit_price %></p>
+      <p>Status: <%= item.invoice_item(@invoice).status %></p>
+    </li>
+  <% end %>
+</ul>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe 'Merchant Index Show Page' do
 
 # alaina_invoice1 should have, from Jewelry, gold earrings and silver necklace, NOT studded bracelet. should also have licorice id, but that should not be shown for this merchant
   let!(:alainainvoice1_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: gold_earrings.id, quantity: 4, unit_price: 1300, status:"packaged" )}
-  let!(:alainainvoice1_itemsilver_necklace) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: silver_necklace.id, quantity: 4, unit_price: 1300, status:"packaged" )}
+# how can this be?
+  let!(:alainainvoice9_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: gold_earrings.id, quantity: 6, unit_price: 1111, status:"shipped" )}
+  
+  let!(:alainainvoice1_itemsilver_necklace) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: silver_necklace.id, quantity: 7, unit_price: 1500, status:"packaged" )}
   let!(:alainainvoice1_itemglicorice) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: licorice.id, quantity: 4, unit_price: 1300, status:"packaged" )}
 
   #this invoice contains an item belonging to this merchant, but no info should be should on invoice1 show page
@@ -38,13 +41,11 @@ RSpec.describe 'Merchant Index Show Page' do
 
     describe 'I see all of MY items on the invoice' do
 
-      it 'displays the name of each merchant item on the invoice'
+      it 'displays the name of each merchant item on the invoice' do
         visit merchant_invoice_path(jewlery_city, alaina_invoice1)
-        expect(page).to have_content("Invoice ##{alaina_invoice1.id}")
-
         within("#invoice_items") do
-          expect(page).to have_content(gold_earrings.name)
           expect(page).to have_content(silver_necklace.name)
+          expect(page).to have_content(gold_earrings.name)
           #checks we are not displaying items from a different invoice
           expect(page).to_not have_content(studded_bracelet.name)
           #checks we are not displaying items on this invoice from another merchant
@@ -53,13 +54,15 @@ RSpec.describe 'Merchant Index Show Page' do
       end
 
       it 'displays the quantity, sale price, and status for each item' do
-        within("##{gold_earrings.name}") do
+        visit merchant_invoice_path(jewlery_city, alaina_invoice1)
+        save_and_open_page
+        within("#item_#{gold_earrings.id}") do
           expect(page).to have_content("Quantity: #{alainainvoice1_itemgold_earrings.quantity}")
           expect(page).to have_content("Sale Price: #{alainainvoice1_itemgold_earrings.unit_price}")
           expect(page).to have_content("Status: #{alainainvoice1_itemgold_earrings.status}")
         end
 
-        within("##{silver_necklace.name}") do
+        within("#item_#{silver_necklace.id}") do
           expect(page).to have_content("Quantity: #{alainainvoice1_itemsilver_necklace.quantity}")
           expect(page).to have_content("Sale Price: #{alainainvoice1_itemsilver_necklace.unit_price}")
           expect(page).to have_content("Status: #{alainainvoice1_itemsilver_necklace.status}")
@@ -67,3 +70,4 @@ RSpec.describe 'Merchant Index Show Page' do
       end
     end
   end
+end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe 'Merchant Index Show Page' do
         visit merchant_invoice_path(jewlery_city, alaina_invoice1)
         save_and_open_page
         within("#item_#{gold_earrings.id}") do
-          expect(page).to have_content("Quantity: #{alainainvoice1_itemgold_earrings.quantity}")
-          expect(page).to have_content("Sale Price: #{alainainvoice1_itemgold_earrings.unit_price}")
-          expect(page).to have_content("Status: #{alainainvoice1_itemgold_earrings.status}")
+          expect(page).to have_content("Quantity: #{alainainvoice9_itemgold_earrings.quantity}")
+          expect(page).to have_content("Sale Price: #{alainainvoice9_itemgold_earrings.unit_price}")
+          expect(page).to have_content("Status: #{alainainvoice9_itemgold_earrings.status}")
         end
 
         within("#item_#{silver_necklace.id}") do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -55,11 +55,35 @@ RSpec.describe Invoice, type: :model do
       let!(:whitneyinvoice1_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice1.id, item_id: silver_necklace.id, quantity: 3, unit_price: 270, status:"packaged" )}
       let!(:whitneyinvoice2_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice2.id, item_id: silver_necklace.id, quantity: 31, unit_price: 270, status:"shipped" )}
       let!(:whitneyinvoice3_itemsilver_necklace) { InvoiceItem.create!(invoice_id: whitney_invoice3.id, item_id: silver_necklace.id, quantity: 1, unit_price: 270, status:"shipped" )}
+
      it 'can return the invoices where the merchant has at least one item on that invoice' do 
 
       expect(jewlery_city.find_relevant_invoices).to include(alaina_invoice1, alaina_invoice2, alaina_invoice3, whitney_invoice1, whitney_invoice2, whitney_invoice3)
       expect(jewlery_city.find_relevant_invoices).to_not include(alaina_invoice4)
      end
+    end
+
+    describe '#merchant_items' do
+      let!(:jewlery_city) { Merchant.create!(name: "Jewlery City Merchant")}
+      let!(:carly_silo) { Merchant.create!(name: "Carly Simon's Candy Silo")}
+
+      let!(:gold_earrings) { jewlery_city.items.create!(name: "Gold Earrings", description: "14k Gold 12' Hoops", unit_price: 12000) }
+      let!(:silver_necklace) { jewlery_city.items.create!(name: "Silver Necklace", description: "An everyday wearable silver necklace", unit_price: 220000) }
+      let!(:licorice) { carly_silo.items.create!(name: "Licorice Funnels", description: "Licorice Balls", unit_price: 1200, enabled: true) }
+
+      let!(:alaina) { Customer.create!(first_name: "Alaina", last_name: "Kneiling")}
+
+      let!(:alaina_invoice1) { alaina.invoices.create!(status: "completed")}
+
+      let!(:alainainvoice1_itemgold_earrings) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: gold_earrings.id, quantity: 4, unit_price: 1300, status:"packaged" )}
+      let!(:alainainvoice1_itemsilver_necklace) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: silver_necklace.id, quantity: 4, unit_price: 1300, status:"packaged" )}
+      let!(:alainainvoice1_itemglicorice) { InvoiceItem.create!(invoice_id: alaina_invoice1.id, item_id: licorice.id, quantity: 4, unit_price: 1300, status:"packaged" )}
+
+
+      it 'takes a merchant as an arg and returns an array of items from that merchant which appear on the invoice' do
+        expect(alaina_invoice1.merchant_items).to include(gold_earrings, silver_necklace)
+        expect(alaina_invoice1.merchant_items).to_not include(licorice)
+      end
     end
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Item, type: :model do
   let!(:gordy_inv4) { gordy.invoices.create!(status: "completed", created_at: "2012-05-25 14:54:09", updated_at: "2012-05-25 14:54:09") }
   let!(:transaction4) { gordy_inv4.transactions.create!(credit_card_number: "1935292921010120202", result: "success")}
   let!(:item_inv1) { InvoiceItem.create!}
-  
+
   let!(:item_inv1) { InvoiceItem.create!(invoice_id: gordy_inv1.id, item_id: rocker.id, quantity: 4, unit_price: 1300, status:"packaged" )}
   let!(:item_inv2) { InvoiceItem.create!(invoice_id: gordy_inv2.id, item_id: rocker.id, quantity: 4, unit_price: 1400, status:"packaged" )}
   let!(:item_inv3) { InvoiceItem.create!(invoice_id: gordy_inv3.id, item_id: rocker.id, quantity: 10, unit_price: 1600, status:"packaged" )}
@@ -48,6 +48,12 @@ RSpec.describe Item, type: :model do
      it 'description of method' do
       #expect statement here
      end
+    end
+
+    describe '#invoice_item(invoice)' do
+      it 'returns an InvoiceItem object given an invoice' do
+        expect(rocker.invoice_item(gordy_inv1)).to eq(item_inv1)
+      end
     end
 
     describe '#best_sales_date' do


### PR DESCRIPTION
Wrote methods to return a merchant's items on an invoice, and to return an invoice items object for a given item and invoice.

Merchant invoice show page now displays a list of that merchant's items that appear on the invoice, as well as listing shipping status, quantity and sale price for each item.