### PR TITLE
#8   admin merchant update

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -6,4 +6,25 @@ class Admin::MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
+
+  def edit
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def update
+    @merchant = Merchant.find(params[:id])
+    if params[:name].gsub(' ', '') == ""
+      flash[:notice] = 'Empty name not permitted. Please try again.'
+      redirect_to edit_admin_merchant_path(@merchant)
+    else
+      @merchant.update(merchant_params)
+      flash[:notice] = 'Merchant has been successfully updated.'
+      redirect_to admin_merchant_path(@merchant)
+    end
+  end
+
+  private
+  def merchant_params
+    params.permit(:name)
+  end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing Merchant: "<%= @merchant.name%>"</h1>
+
+<p><%= flash.notice %></p>
+
+
+<%= form_with url: admin_merchant_path, method: :patch, local: true do |f|%>
+  <%= f.label :name, 'Name'%>
+  <%= f.text_field :name, value: @merchant.name, style: "width: 200px"%>
+  <%= f.submit 'Submit'%>
+<%end%>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,1 +1,5 @@
 <div id='merchant-name'><h1><%=@merchant.name%></h1></div>
+
+<p><%= flash.notice %></p>
+
+<p><%= link_to 'Update Merchant', edit_admin_merchant_path(@merchant) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   resources :admin, only: [:index]
 
   namespace :admin do
-    resources :merchants, only: [:index, :show]
+    resources :merchants
     resources :invoices, only: [:index, :show]
   end
 

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.shared_context 'merchant edit' do
+  def name_update
+    fill_in 'Name', with: "Carlos Simon's Candy Silo"
+    click_on 'Submit'
+  end
+end
+
+RSpec.describe 'Admin Merchant Show', type: :feature do
+
+  let!(:carly) { Merchant.create!(name: "Carly Simon's Candy Silo") }
+
+  describe 'As an admin, when I visit admin merchants show' do
+    before(:each) do
+      visit edit_admin_merchant_path(carly)
+    end
+
+    it 'has a form filled in with the existing merchant attribute information' do
+      expect(page).to have_field('Name', with: carly.name)
+    end
+
+    include_context 'merchant edit'
+
+    it 'When I update the information in the form and I click "submit" then I am redirected back to the merchants admin show page' do
+      name_update
+
+      expect(current_path).to eq(admin_merchant_path(carly))
+    end
+
+    it 'where I see the updated information' do
+      name_update
+
+      within '#merchant-name' do
+        expect(page).to have_content("Carlos Simon's Candy Silo")
+      end
+    end
+
+    it 'And I see a flash message stating that the information has been successfully updated.' do
+      name_update
+
+      expect(flash[:success]).to eq('Merchant has been successfully updated')
+    end
+  end
+end

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -7,7 +7,7 @@ RSpec.shared_context 'merchant edit' do
   end
 end
 
-RSpec.describe 'Admin Merchant Show', type: :feature do
+RSpec.describe 'Admin Merchant Edit', type: :feature do
 
   let!(:carly) { Merchant.create!(name: "Carly Simon's Candy Silo") }
 
@@ -39,7 +39,23 @@ RSpec.describe 'Admin Merchant Show', type: :feature do
     it 'And I see a flash message stating that the information has been successfully updated.' do
       name_update
 
-      expect(flash[:success]).to eq('Merchant has been successfully updated')
+      expect(page).to have_content('Merchant has been successfully updated.')
+    end
+
+    it 'and if I leave it blank it refreshes the page and flashes an error' do
+      fill_in 'Name', with: ""
+      click_on 'Submit'
+
+      expect(current_path).to eq(edit_admin_merchant_path(carly))
+      expect(page).to have_content('Empty name not permitted. Please try again.')
+    end
+
+    it 'and if I fill it with nothing but spaces but it refreshes the page and flashes an error' do
+      fill_in 'Name', with: "   "
+      click_on 'Submit'
+
+      expect(current_path).to eq(edit_admin_merchant_path(carly))
+      expect(page).to have_content('Empty name not permitted. Please try again.')
     end
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Admin Merchant Show', type: :feature do
       it 'when I click the link then I am taken to a page to edit this merchant' do
         expect(page).to have_link("Update Merchant")
         click_on "Update Merchant"
-        expect(current_path).to eq("/admin/#{carly.id}/edit")
+        expect(current_path).to eq("/admin/merchants/#{carly.id}/edit")
       end
     end
   end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -97,5 +97,13 @@ RSpec.describe 'Admin Merchant Show', type: :feature do
         expect(page).to have_content(carly.name)
       end
     end
+
+    describe 'it has a link to update merchants information' do 
+      it 'when I click the link then I am taken to a page to edit this merchant' do
+        expect(page).to have_link("Update Merchant")
+        click_on "Update Merchant"
+        expect(current_path).to eq("/admin/#{carly.id}/edit")
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey Y'all! Couple things about this PR: 

1. I used this neat rspec feature called `shared_context` that basically functions like a module for rspec (it can define variables too though). Check it out at the top of `/spec/features/admin/merchants`, might be useful in the future. 

2.  I did some super quick sad path testing which I think is a requirement on the presentation so just wanted to let yall know. 

3. And last, I had to remove the `only: [:index,:show]` from the admin merchant routes because I couldn't get it to work with just putting [:edit] in there. Maybe I needed to do [:update] too? 

I also wanted to ask about the before_action bits at the top of `ItemsController`. Do they just do `@___ = ____.find` or whatever you need? if so, that's super convenient! 