### PR TITLE
fix failures caused by require github_services

### DIFF
--- a/app/facades/github_facade.rb
+++ b/app/facades/github_facade.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'github_service'
+require './app/services/github_service'
 
 class GitHubFacade
 

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,5 +1,4 @@
 require 'httparty'
-require 'github_facade'
 
 class GitHubService
   def self.request(path, auth_required = false)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,8 +3,6 @@ require 'spec_helper'
 require './app/facades/github_facade'
 require './app/services/github_service'
 
-
-
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'github_service'
 require 'webmock/rspec'
 
 RSpec.describe 'github service' do


### PR DESCRIPTION
github_services and _facades aren't seen by rails in the same way that our other files in MVC link together. This should sort out some of the problems that resulted from things needing to know about them.